### PR TITLE
Document Hotspot compressed OOPS are supported

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -11,7 +11,7 @@ The following programming languages are currently supported:
 * C/C++
 * Go
 * Rust
-* Java HotSpot (JDK 7-16, AOT and compressed pointers are not supported)
+* Java HotSpot (JDK 7-16, AOT is not supported)
 * Python 3.6-3.10
 * PHP 7.3-7.4
 * Ruby 2.5-3.0.1


### PR DESCRIPTION
With this commit we remove a statement from the FAQ that mentions compressed pointers are unsupported for profiling Hotspot-based applications. This turns out to be wrong: compressed pointers are actually not relevant for the profiler.